### PR TITLE
Stable per-app audio control using application name

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "Name": "PipeWire Audio Control",
   "Description": "Native PipeWire audio control for Linux — master volume, mic, and per-app control.",
   "Author": "sfgrimes",
-  "Version": "0.1.11",
+  "Version": "0.1.12",
   "Icon": "icons/plugin",
   "Category": "Audio",
   "CategoryIcon": "icons/plugin",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "com.sfgrimes.pipewire-audio",
-  "version": "0.1.11",
+  "version": "0.1.12",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "com.sfgrimes.pipewire-audio",
-      "version": "0.1.11",
+      "version": "0.1.12",
       "license": "GPL-3.0-only",
       "dependencies": {
         "ws": "^8.18.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.sfgrimes.pipewire-audio",
-  "version": "0.1.11",
+  "version": "0.1.12",
   "description": "PipeWire Native Audio Control Plugin for OpenDeck",
   "main": "index.js",
   "author": "sfgrimes",

--- a/pipewire.js
+++ b/pipewire.js
@@ -64,6 +64,7 @@ function parsePwDump(callback) {
           apps.push({
             id: node.id,
             name: props["application.name"] || props["node.name"] || `Node ${node.id}`,
+            appName: props["application.name"] || null,
           });
         } else if (mediaClass === "Audio/Sink") {
           sinks.push({
@@ -110,6 +111,14 @@ function resolveNodeId(nodeName, callback) {
   parsePwDump((apps, sinks) => {
     const match = sinks.find((s) => s.nodeName === nodeName);
     callback(match ? match.id : null);
+  });
+}
+
+// Resolve a stable application.name to all current matching node IDs (for app streams)
+function resolveAppIds(appName, callback) {
+  parsePwDump((apps) => {
+    const ids = apps.filter((a) => a.appName === appName).map((a) => a.id);
+    callback(ids);
   });
 }
 
@@ -168,6 +177,7 @@ module.exports = {
   getAppName,
   resolveNodeId,
   resolveSourceId,
+  resolveAppIds,
   setDefault,
   nodeVolume,
   nodeMute,

--- a/propertyInspector/appSettings.html
+++ b/propertyInspector/appSettings.html
@@ -64,11 +64,24 @@
       }
     );
 
+    var cachedApps = [];
+
     function populateAppList(apps) {
+      cachedApps = apps;
       var select = document.getElementById("app-select");
       select.innerHTML = "";
 
-      if (apps.length === 0) {
+      // Deduplicate by appName
+      var seen = {};
+      var unique = [];
+      apps.forEach(function (app) {
+        if (app.appName && !seen[app.appName]) {
+          seen[app.appName] = true;
+          unique.push(app);
+        }
+      });
+
+      if (unique.length === 0) {
         var opt = document.createElement("option");
         opt.value = "";
         opt.textContent = "No audio streams found";
@@ -83,23 +96,32 @@
       placeholder.disabled = true;
       select.appendChild(placeholder);
 
-      apps.forEach(function (app) {
+      unique.forEach(function (app) {
         var opt = document.createElement("option");
-        opt.value = String(app.id);
-        opt.textContent = app.name + " (ID: " + app.id + ")";
+        opt.value = app.appName;
+        opt.textContent = app.name;
         select.appendChild(opt);
       });
+
+      // Auto-migrate from legacy numeric ID
+      if (!settings.appName && settings.app) {
+        var match = apps.find(function (a) { return String(a.id) === String(settings.app); });
+        if (match && match.appName) {
+          settings.appName = match.appName;
+          sendSettings();
+        }
+      }
 
       selectCurrentApp();
     }
 
     function selectCurrentApp() {
       var select = document.getElementById("app-select");
-      if (settings.app) select.value = String(settings.app);
+      if (settings.appName) select.value = settings.appName;
     }
 
     function saveSettings() {
-      settings.app = document.getElementById("app-select").value || settings.app;
+      settings.appName = document.getElementById("app-select").value || settings.appName;
       saveDisplaySettings();
       saveVolumeStep();
       sendSettings();


### PR DESCRIPTION
Quality of life update for per-app volume control. 
 
* Per-app actions now store a stable application.name instead of a numeric PipeWire node ID.
 * Volume and mute commands apply to all streams matching the app name (e.g. two Firefox
  windows both get controlled)