### PR TITLE
Keypad updates

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -3,7 +3,6 @@ set -euo pipefail
 
 PLUGIN_NAME="com.sfgrimes.pipewire-audio"
 STAGE_DIR="${PLUGIN_NAME}.sdPlugin"
-OUTPUT="builds/${PLUGIN_NAME}.streamDeckPlugin"
 
 cd "$(dirname "$0")"
 
@@ -20,6 +19,7 @@ NEW_VERSION=$(node -e "
   fs.writeFileSync('package.json', JSON.stringify(p, null, 2) + '\n');
   process.stdout.write(v);
 ")
+OUTPUT="builds/${PLUGIN_NAME}-${NEW_VERSION}.streamDeckPlugin"
 echo "Version: $NEW_VERSION"
 
 echo "Installing dependencies..."

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "Name": "PipeWire Audio Control",
   "Description": "Native PipeWire audio control for Linux — master volume, mic, and per-app control.",
   "Author": "sfgrimes",
-  "Version": "0.1.12",
+  "Version": "0.2.1",
   "Icon": "icons/plugin",
   "Category": "Audio",
   "CategoryIcon": "icons/plugin",
@@ -39,7 +39,7 @@
       "States": [
         {
           "Image": "icons/volume-up",
-          "TitleAlignment": "middle"
+          "TitleAlignment": "top"
         }
       ]
     },
@@ -64,7 +64,7 @@
       "States": [
         {
           "Image": "icons/volume-down",
-          "TitleAlignment": "middle"
+          "TitleAlignment": "top"
         }
       ]
     },
@@ -90,12 +90,12 @@
         {
           "Image": "icons/mute-toggle",
           "Name": "Unmuted",
-          "TitleAlignment": "middle"
+          "TitleAlignment": "top"
         },
         {
           "Image": "icons/mute-toggle",
           "Name": "Muted",
-          "TitleAlignment": "middle"
+          "TitleAlignment": "top"
         }
       ]
     },
@@ -120,7 +120,7 @@
       "States": [
         {
           "Image": "icons/mic-up",
-          "TitleAlignment": "middle"
+          "TitleAlignment": "top"
         }
       ]
     },
@@ -145,7 +145,7 @@
       "States": [
         {
           "Image": "icons/mic-down",
-          "TitleAlignment": "middle"
+          "TitleAlignment": "top"
         }
       ]
     },
@@ -171,12 +171,12 @@
         {
           "Image": "icons/mic-mute",
           "Name": "Unmuted",
-          "TitleAlignment": "middle"
+          "TitleAlignment": "top"
         },
         {
           "Image": "icons/mic-mute",
           "Name": "Muted",
-          "TitleAlignment": "middle"
+          "TitleAlignment": "top"
         }
       ]
     },
@@ -201,7 +201,7 @@
       "States": [
         {
           "Image": "icons/app-volume-up",
-          "TitleAlignment": "middle"
+          "TitleAlignment": "top"
         }
       ]
     },
@@ -226,7 +226,7 @@
       "States": [
         {
           "Image": "icons/app-volume-down",
-          "TitleAlignment": "middle"
+          "TitleAlignment": "top"
         }
       ]
     },
@@ -252,12 +252,12 @@
         {
           "Image": "icons/app-mute",
           "Name": "Unmuted",
-          "TitleAlignment": "middle"
+          "TitleAlignment": "top"
         },
         {
           "Image": "icons/app-mute",
           "Name": "Muted",
-          "TitleAlignment": "middle"
+          "TitleAlignment": "top"
         }
       ]
     },
@@ -282,7 +282,7 @@
       "States": [
         {
           "Image": "icons/output-volume-up",
-          "TitleAlignment": "middle"
+          "TitleAlignment": "top"
         }
       ]
     },
@@ -307,7 +307,7 @@
       "States": [
         {
           "Image": "icons/output-volume-down",
-          "TitleAlignment": "middle"
+          "TitleAlignment": "top"
         }
       ]
     },
@@ -333,12 +333,12 @@
         {
           "Image": "icons/output-mute",
           "Name": "Unmuted",
-          "TitleAlignment": "middle"
+          "TitleAlignment": "top"
         },
         {
           "Image": "icons/output-mute",
           "Name": "Muted",
-          "TitleAlignment": "middle"
+          "TitleAlignment": "top"
         }
       ]
     },
@@ -363,7 +363,7 @@
       "States": [
         {
           "Image": "icons/mic-up",
-          "TitleAlignment": "middle"
+          "TitleAlignment": "top"
         }
       ]
     },
@@ -388,7 +388,7 @@
       "States": [
         {
           "Image": "icons/mic-down",
-          "TitleAlignment": "middle"
+          "TitleAlignment": "top"
         }
       ]
     },
@@ -414,12 +414,12 @@
         {
           "Image": "icons/mic-mute",
           "Name": "Unmuted",
-          "TitleAlignment": "middle"
+          "TitleAlignment": "top"
         },
         {
           "Image": "icons/mic-mute",
           "Name": "Muted",
-          "TitleAlignment": "middle"
+          "TitleAlignment": "top"
         }
       ]
     },
@@ -445,12 +445,12 @@
         {
           "Image": "icons/output-volume-up",
           "Name": "Active",
-          "TitleAlignment": "middle"
+          "TitleAlignment": "top"
         },
         {
           "Image": "icons/output-volume-up",
           "Name": "Inactive",
-          "TitleAlignment": "middle"
+          "TitleAlignment": "top"
         }
       ]
     },
@@ -476,12 +476,12 @@
         {
           "Image": "icons/mic-up",
           "Name": "Active",
-          "TitleAlignment": "middle"
+          "TitleAlignment": "top"
         },
         {
           "Image": "icons/mic-up",
           "Name": "Inactive",
-          "TitleAlignment": "middle"
+          "TitleAlignment": "top"
         }
       ]
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "com.sfgrimes.pipewire-audio",
-  "version": "0.1.12",
+  "version": "0.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "com.sfgrimes.pipewire-audio",
-      "version": "0.1.12",
+      "version": "0.2.1",
       "license": "GPL-3.0-only",
       "dependencies": {
         "ws": "^8.18.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.sfgrimes.pipewire-audio",
-  "version": "0.1.12",
+  "version": "0.2.1",
   "description": "PipeWire Native Audio Control Plugin for OpenDeck",
   "main": "index.js",
   "author": "sfgrimes",

--- a/propertyInspector/appSettings.html
+++ b/propertyInspector/appSettings.html
@@ -18,12 +18,25 @@
     </div>
     <div class="sdpi-info">Select the PipeWire audio stream to control.</div>
 
-    <div class="sdpi-heading">Encoder Display</div>
+    <div class="sdpi-heading">Display</div>
+    <div class="sdpi-item">
+      <div class="sdpi-item-label">Custom Name</div>
+      <div class="sdpi-item-value">
+        <input type="text" id="customName" placeholder="Leave blank for auto-detect" />
+      </div>
+    </div>
     <div class="sdpi-item">
       <div class="sdpi-item-label">Options</div>
       <div class="sdpi-item-value">
         <input type="checkbox" id="showName" checked />
         <label for="showName">Show device name</label>
+      </div>
+    </div>
+    <div class="sdpi-item">
+      <div class="sdpi-item-label"></div>
+      <div class="sdpi-item-value">
+        <input type="checkbox" id="showBar" checked />
+        <label for="showBar">Show volume bar</label>
       </div>
     </div>
     <div class="sdpi-item">
@@ -132,7 +145,9 @@
     });
 
     document.getElementById("app-select").addEventListener("change", saveSettings);
+    document.getElementById("customName").addEventListener("change", saveSettings);
     document.getElementById("showName").addEventListener("change", saveSettings);
+    document.getElementById("showBar").addEventListener("change", saveSettings);
     document.getElementById("showPercent").addEventListener("change", saveSettings);
     document.getElementById("volumeStep").addEventListener("change", saveSettings);
   </script>

--- a/propertyInspector/encoderSettings.html
+++ b/propertyInspector/encoderSettings.html
@@ -7,12 +7,25 @@
 </head>
 <body>
   <div class="sdpi-wrapper">
-    <div class="sdpi-heading">Encoder Display</div>
+    <div class="sdpi-heading">Display</div>
+    <div class="sdpi-item">
+      <div class="sdpi-item-label">Custom Name</div>
+      <div class="sdpi-item-value">
+        <input type="text" id="customName" placeholder="Leave blank for auto-detect" />
+      </div>
+    </div>
     <div class="sdpi-item">
       <div class="sdpi-item-label">Options</div>
       <div class="sdpi-item-value">
         <input type="checkbox" id="showName" checked />
         <label for="showName">Show device name</label>
+      </div>
+    </div>
+    <div class="sdpi-item">
+      <div class="sdpi-item-label"></div>
+      <div class="sdpi-item-value">
+        <input type="checkbox" id="showBar" checked />
+        <label for="showBar">Show volume bar</label>
       </div>
     </div>
     <div class="sdpi-item">
@@ -47,7 +60,9 @@
       document.getElementById("volumeStepLabel").textContent = this.value + "%";
     });
 
+    document.getElementById("customName").addEventListener("change", saveSettings);
     document.getElementById("showName").addEventListener("change", saveSettings);
+    document.getElementById("showBar").addEventListener("change", saveSettings);
     document.getElementById("showPercent").addEventListener("change", saveSettings);
     document.getElementById("volumeStep").addEventListener("change", saveSettings);
   </script>

--- a/propertyInspector/inputSettings.html
+++ b/propertyInspector/inputSettings.html
@@ -18,12 +18,25 @@
     </div>
     <div class="sdpi-info">Select the PipeWire input device to control.</div>
 
-    <div class="sdpi-heading">Encoder Display</div>
+    <div class="sdpi-heading">Display</div>
+    <div class="sdpi-item">
+      <div class="sdpi-item-label">Custom Name</div>
+      <div class="sdpi-item-value">
+        <input type="text" id="customName" placeholder="Leave blank for auto-detect" />
+      </div>
+    </div>
     <div class="sdpi-item">
       <div class="sdpi-item-label">Options</div>
       <div class="sdpi-item-value">
         <input type="checkbox" id="showName" checked />
         <label for="showName">Show device name</label>
+      </div>
+    </div>
+    <div class="sdpi-item">
+      <div class="sdpi-item-label"></div>
+      <div class="sdpi-item-value">
+        <input type="checkbox" id="showBar" checked />
+        <label for="showBar">Show volume bar</label>
       </div>
     </div>
     <div class="sdpi-item">
@@ -110,7 +123,9 @@
     });
 
     document.getElementById("input-select").addEventListener("change", saveSettings);
+    document.getElementById("customName").addEventListener("change", saveSettings);
     document.getElementById("showName").addEventListener("change", saveSettings);
+    document.getElementById("showBar").addEventListener("change", saveSettings);
     document.getElementById("showPercent").addEventListener("change", saveSettings);
     document.getElementById("volumeStep").addEventListener("change", saveSettings);
   </script>

--- a/propertyInspector/outputSettings.html
+++ b/propertyInspector/outputSettings.html
@@ -18,12 +18,25 @@
     </div>
     <div class="sdpi-info">Select the PipeWire output device to control.</div>
 
-    <div class="sdpi-heading">Encoder Display</div>
+    <div class="sdpi-heading">Display</div>
+    <div class="sdpi-item">
+      <div class="sdpi-item-label">Custom Name</div>
+      <div class="sdpi-item-value">
+        <input type="text" id="customName" placeholder="Leave blank for auto-detect" />
+      </div>
+    </div>
     <div class="sdpi-item">
       <div class="sdpi-item-label">Options</div>
       <div class="sdpi-item-value">
         <input type="checkbox" id="showName" checked />
         <label for="showName">Show device name</label>
+      </div>
+    </div>
+    <div class="sdpi-item">
+      <div class="sdpi-item-label"></div>
+      <div class="sdpi-item-value">
+        <input type="checkbox" id="showBar" checked />
+        <label for="showBar">Show volume bar</label>
       </div>
     </div>
     <div class="sdpi-item">
@@ -121,7 +134,9 @@
     });
 
     document.getElementById("output-select").addEventListener("change", saveSettings);
+    document.getElementById("customName").addEventListener("change", saveSettings);
     document.getElementById("showName").addEventListener("change", saveSettings);
+    document.getElementById("showBar").addEventListener("change", saveSettings);
     document.getElementById("showPercent").addEventListener("change", saveSettings);
     document.getElementById("volumeStep").addEventListener("change", saveSettings);
   </script>

--- a/propertyInspector/sdpi-common.js
+++ b/propertyInspector/sdpi-common.js
@@ -54,14 +54,21 @@ function initPI(onReady, onMessage) {
 
 function loadDisplaySettings() {
   var showNameEl = document.getElementById("showName");
+  var showBarEl = document.getElementById("showBar");
   var showPercentEl = document.getElementById("showPercent");
+  var customNameEl = document.getElementById("customName");
   if (showNameEl) showNameEl.checked = settings.showName !== false;
+  if (showBarEl) showBarEl.checked = settings.showBar !== false;
   if (showPercentEl) showPercentEl.checked = settings.showPercent === true;
+  if (customNameEl) customNameEl.value = settings.customName || "";
 }
 
 function saveDisplaySettings() {
   settings.showName = document.getElementById("showName").checked;
+  settings.showBar = document.getElementById("showBar").checked;
   settings.showPercent = document.getElementById("showPercent").checked;
+  var customNameEl = document.getElementById("customName");
+  if (customNameEl) settings.customName = customNameEl.value;
 }
 
 function loadVolumeStep() {

--- a/propertyInspector/switchSettings.html
+++ b/propertyInspector/switchSettings.html
@@ -18,12 +18,25 @@
     </div>
     <div class="sdpi-info">Select the device to set as system default when pressed.</div>
 
-    <div class="sdpi-heading">Encoder Display</div>
+    <div class="sdpi-heading">Display</div>
+    <div class="sdpi-item">
+      <div class="sdpi-item-label">Custom Name</div>
+      <div class="sdpi-item-value">
+        <input type="text" id="customName" placeholder="Leave blank for auto-detect" />
+      </div>
+    </div>
     <div class="sdpi-item">
       <div class="sdpi-item-label">Options</div>
       <div class="sdpi-item-value">
         <input type="checkbox" id="showName" checked />
         <label for="showName">Show device name</label>
+      </div>
+    </div>
+    <div class="sdpi-item">
+      <div class="sdpi-item-label"></div>
+      <div class="sdpi-item-value">
+        <input type="checkbox" id="showBar" checked />
+        <label for="showBar">Show volume bar</label>
       </div>
     </div>
     <div class="sdpi-item">
@@ -103,7 +116,9 @@
     }
 
     document.getElementById("device-select").addEventListener("change", saveSettings);
+    document.getElementById("customName").addEventListener("change", saveSettings);
     document.getElementById("showName").addEventListener("change", saveSettings);
+    document.getElementById("showBar").addEventListener("change", saveSettings);
     document.getElementById("showPercent").addEventListener("change", saveSettings);
   </script>
 </body>


### PR DESCRIPTION
  - Keypad volume controls now have unique icons that indicate function. 
  - Use native setTitle for keypad name instead of SVG text rendering
  - Add "Show volume bar" toggle (showBar setting, default on)
  - Add "Custom Name" text field to override auto-detected device/app name
  - Thinner volume bar (8→6px height, rx 4→3)
  - Smaller font sizes (18→16) for percentage text