### PR TITLE
BREAKING: Consolidate actions — buttons must be rebuilt

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "Name": "PipeWire Audio Control",
   "Description": "Native PipeWire audio control for Linux — master volume, mic, and per-app control.",
   "Author": "sfgrimes",
-  "Version": "0.2.1",
+  "Version": "0.2.4",
   "Icon": "icons/plugin",
   "Category": "Audio",
   "CategoryIcon": "icons/plugin",
@@ -19,10 +19,10 @@
   "SDKVersion": 2,
   "Actions": [
     {
-      "UUID": "com.sfgrimes.pipewire-audio.volumeup",
-      "Name": "Volume Up",
+      "UUID": "com.sfgrimes.pipewire-audio.volume",
+      "Name": "Master Volume",
       "Icon": "icons/volume-up",
-      "Tooltip": "Increase master volume by 5%",
+      "Tooltip": "Increase or decrease master volume",
       "Controllers": [
         "Keypad",
         "Encoder"
@@ -39,56 +39,6 @@
       "States": [
         {
           "Image": "icons/volume-up",
-          "TitleAlignment": "top"
-        }
-      ]
-    },
-    {
-      "UUID": "com.sfgrimes.pipewire-audio.volumedown",
-      "Name": "Volume Down",
-      "Icon": "icons/volume-down",
-      "Tooltip": "Decrease master volume by 5%",
-      "Controllers": [
-        "Keypad",
-        "Encoder"
-      ],
-      "Encoder": {
-        "layout": "$B1",
-        "TriggerDescription": {
-          "Rotate": "Adjust volume",
-          "Push": "Toggle mute",
-          "Touch": "Toggle mute"
-        }
-      },
-      "PropertyInspectorPath": "propertyInspector/encoderSettings.html",
-      "States": [
-        {
-          "Image": "icons/volume-down",
-          "TitleAlignment": "top"
-        }
-      ]
-    },
-    {
-      "UUID": "com.sfgrimes.pipewire-audio.mutetoggle",
-      "Name": "Mute Toggle",
-      "Icon": "icons/mute-toggle",
-      "Tooltip": "Toggle master audio mute",
-      "Controllers": [
-        "Keypad",
-        "Encoder"
-      ],
-      "Encoder": {
-        "layout": "$B1",
-        "TriggerDescription": {
-          "Rotate": "Adjust volume",
-          "Push": "Toggle mute",
-          "Touch": "Toggle mute"
-        }
-      },
-      "PropertyInspectorPath": "propertyInspector/encoderSettings.html",
-      "States": [
-        {
-          "Image": "icons/mute-toggle",
           "Name": "Unmuted",
           "TitleAlignment": "top"
         },
@@ -100,10 +50,10 @@
       ]
     },
     {
-      "UUID": "com.sfgrimes.pipewire-audio.micup",
-      "Name": "Mic Volume Up",
+      "UUID": "com.sfgrimes.pipewire-audio.micvolume",
+      "Name": "Mic Volume",
       "Icon": "icons/mic-up",
-      "Tooltip": "Increase microphone volume by 5%",
+      "Tooltip": "Increase or decrease microphone volume",
       "Controllers": [
         "Keypad",
         "Encoder"
@@ -120,56 +70,6 @@
       "States": [
         {
           "Image": "icons/mic-up",
-          "TitleAlignment": "top"
-        }
-      ]
-    },
-    {
-      "UUID": "com.sfgrimes.pipewire-audio.micdown",
-      "Name": "Mic Volume Down",
-      "Icon": "icons/mic-down",
-      "Tooltip": "Decrease microphone volume by 5%",
-      "Controllers": [
-        "Keypad",
-        "Encoder"
-      ],
-      "Encoder": {
-        "layout": "$B1",
-        "TriggerDescription": {
-          "Rotate": "Adjust mic volume",
-          "Push": "Toggle mic mute",
-          "Touch": "Toggle mic mute"
-        }
-      },
-      "PropertyInspectorPath": "propertyInspector/encoderSettings.html",
-      "States": [
-        {
-          "Image": "icons/mic-down",
-          "TitleAlignment": "top"
-        }
-      ]
-    },
-    {
-      "UUID": "com.sfgrimes.pipewire-audio.micmute",
-      "Name": "Mic Mute Toggle",
-      "Icon": "icons/mic-mute",
-      "Tooltip": "Toggle microphone mute",
-      "Controllers": [
-        "Keypad",
-        "Encoder"
-      ],
-      "Encoder": {
-        "layout": "$B1",
-        "TriggerDescription": {
-          "Rotate": "Adjust mic volume",
-          "Push": "Toggle mic mute",
-          "Touch": "Toggle mic mute"
-        }
-      },
-      "PropertyInspectorPath": "propertyInspector/encoderSettings.html",
-      "States": [
-        {
-          "Image": "icons/mic-mute",
           "Name": "Unmuted",
           "TitleAlignment": "top"
         },
@@ -181,10 +81,10 @@
       ]
     },
     {
-      "UUID": "com.sfgrimes.pipewire-audio.appvolumeup",
-      "Name": "App Volume Up",
+      "UUID": "com.sfgrimes.pipewire-audio.appvolume",
+      "Name": "App Volume",
       "Icon": "icons/app-volume-up",
-      "Tooltip": "Increase application volume by 5%",
+      "Tooltip": "Increase or decrease application volume",
       "Controllers": [
         "Keypad",
         "Encoder"
@@ -201,56 +101,6 @@
       "States": [
         {
           "Image": "icons/app-volume-up",
-          "TitleAlignment": "top"
-        }
-      ]
-    },
-    {
-      "UUID": "com.sfgrimes.pipewire-audio.appvolumedown",
-      "Name": "App Volume Down",
-      "Icon": "icons/app-volume-down",
-      "Tooltip": "Decrease application volume by 5%",
-      "Controllers": [
-        "Keypad",
-        "Encoder"
-      ],
-      "Encoder": {
-        "layout": "$B1",
-        "TriggerDescription": {
-          "Rotate": "Adjust app volume",
-          "Push": "Toggle app mute",
-          "Touch": "Toggle app mute"
-        }
-      },
-      "PropertyInspectorPath": "propertyInspector/appSettings.html",
-      "States": [
-        {
-          "Image": "icons/app-volume-down",
-          "TitleAlignment": "top"
-        }
-      ]
-    },
-    {
-      "UUID": "com.sfgrimes.pipewire-audio.appmute",
-      "Name": "App Mute Toggle",
-      "Icon": "icons/app-mute",
-      "Tooltip": "Toggle application mute",
-      "Controllers": [
-        "Keypad",
-        "Encoder"
-      ],
-      "Encoder": {
-        "layout": "$B1",
-        "TriggerDescription": {
-          "Rotate": "Adjust app volume",
-          "Push": "Toggle app mute",
-          "Touch": "Toggle app mute"
-        }
-      },
-      "PropertyInspectorPath": "propertyInspector/appSettings.html",
-      "States": [
-        {
-          "Image": "icons/app-mute",
           "Name": "Unmuted",
           "TitleAlignment": "top"
         },
@@ -262,10 +112,10 @@
       ]
     },
     {
-      "UUID": "com.sfgrimes.pipewire-audio.outputvolumeup",
-      "Name": "Output Volume Up",
+      "UUID": "com.sfgrimes.pipewire-audio.outputvolume",
+      "Name": "Output Volume",
       "Icon": "icons/output-volume-up",
-      "Tooltip": "Increase output device volume by 5%",
+      "Tooltip": "Increase or decrease output device volume",
       "Controllers": [
         "Keypad",
         "Encoder"
@@ -282,56 +132,6 @@
       "States": [
         {
           "Image": "icons/output-volume-up",
-          "TitleAlignment": "top"
-        }
-      ]
-    },
-    {
-      "UUID": "com.sfgrimes.pipewire-audio.outputvolumedown",
-      "Name": "Output Volume Down",
-      "Icon": "icons/output-volume-down",
-      "Tooltip": "Decrease output device volume by 5%",
-      "Controllers": [
-        "Keypad",
-        "Encoder"
-      ],
-      "Encoder": {
-        "layout": "$B1",
-        "TriggerDescription": {
-          "Rotate": "Adjust output volume",
-          "Push": "Toggle output mute",
-          "Touch": "Toggle output mute"
-        }
-      },
-      "PropertyInspectorPath": "propertyInspector/outputSettings.html",
-      "States": [
-        {
-          "Image": "icons/output-volume-down",
-          "TitleAlignment": "top"
-        }
-      ]
-    },
-    {
-      "UUID": "com.sfgrimes.pipewire-audio.outputmute",
-      "Name": "Output Mute Toggle",
-      "Icon": "icons/output-mute",
-      "Tooltip": "Toggle output device mute",
-      "Controllers": [
-        "Keypad",
-        "Encoder"
-      ],
-      "Encoder": {
-        "layout": "$B1",
-        "TriggerDescription": {
-          "Rotate": "Adjust output volume",
-          "Push": "Toggle output mute",
-          "Touch": "Toggle output mute"
-        }
-      },
-      "PropertyInspectorPath": "propertyInspector/outputSettings.html",
-      "States": [
-        {
-          "Image": "icons/output-mute",
           "Name": "Unmuted",
           "TitleAlignment": "top"
         },
@@ -343,10 +143,10 @@
       ]
     },
     {
-      "UUID": "com.sfgrimes.pipewire-audio.inputvolumeup",
-      "Name": "Input Volume Up",
+      "UUID": "com.sfgrimes.pipewire-audio.inputvolume",
+      "Name": "Input Volume",
       "Icon": "icons/mic-up",
-      "Tooltip": "Increase input device volume",
+      "Tooltip": "Increase or decrease input device volume",
       "Controllers": [
         "Keypad",
         "Encoder"
@@ -363,62 +163,34 @@
       "States": [
         {
           "Image": "icons/mic-up",
-          "TitleAlignment": "top"
-        }
-      ]
-    },
-    {
-      "UUID": "com.sfgrimes.pipewire-audio.inputvolumedown",
-      "Name": "Input Volume Down",
-      "Icon": "icons/mic-down",
-      "Tooltip": "Decrease input device volume",
-      "Controllers": [
-        "Keypad",
-        "Encoder"
-      ],
-      "Encoder": {
-        "layout": "$B1",
-        "TriggerDescription": {
-          "Rotate": "Adjust input volume",
-          "Push": "Toggle input mute",
-          "Touch": "Toggle input mute"
-        }
-      },
-      "PropertyInspectorPath": "propertyInspector/inputSettings.html",
-      "States": [
-        {
-          "Image": "icons/mic-down",
-          "TitleAlignment": "top"
-        }
-      ]
-    },
-    {
-      "UUID": "com.sfgrimes.pipewire-audio.inputmute",
-      "Name": "Input Mute Toggle",
-      "Icon": "icons/mic-mute",
-      "Tooltip": "Toggle input device mute",
-      "Controllers": [
-        "Keypad",
-        "Encoder"
-      ],
-      "Encoder": {
-        "layout": "$B1",
-        "TriggerDescription": {
-          "Rotate": "Adjust input volume",
-          "Push": "Toggle input mute",
-          "Touch": "Toggle input mute"
-        }
-      },
-      "PropertyInspectorPath": "propertyInspector/inputSettings.html",
-      "States": [
-        {
-          "Image": "icons/mic-mute",
           "Name": "Unmuted",
           "TitleAlignment": "top"
         },
         {
           "Image": "icons/mic-mute",
           "Name": "Muted",
+          "TitleAlignment": "top"
+        }
+      ]
+    },
+    {
+      "UUID": "com.sfgrimes.pipewire-audio.pushtotalk",
+      "Name": "Push to Talk",
+      "Icon": "icons/mic-mute",
+      "Tooltip": "Hold to unmute mic. Red = muted, green = live.",
+      "Controllers": [
+        "Keypad"
+      ],
+      "PropertyInspectorPath": "propertyInspector/pushToTalkSettings.html",
+      "States": [
+        {
+          "Image": "icons/mic-mute",
+          "Name": "Idle",
+          "TitleAlignment": "top"
+        },
+        {
+          "Image": "icons/mic-mute",
+          "Name": "Active",
           "TitleAlignment": "top"
         }
       ]

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "com.sfgrimes.pipewire-audio",
-  "version": "0.2.1",
+  "version": "0.2.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "com.sfgrimes.pipewire-audio",
-      "version": "0.2.1",
+      "version": "0.2.4",
       "license": "GPL-3.0-only",
       "dependencies": {
         "ws": "^8.18.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.sfgrimes.pipewire-audio",
-  "version": "0.2.1",
+  "version": "0.2.4",
   "description": "PipeWire Native Audio Control Plugin for OpenDeck",
   "main": "index.js",
   "author": "sfgrimes",

--- a/pipewire.js
+++ b/pipewire.js
@@ -42,6 +42,12 @@ function nodeMute(id, callback) {
   run(`wpctl set-mute ${id} toggle`, callback);
 }
 
+// Set mute to a specific state (true = muted, false = unmuted)
+function nodeMuteSet(id, muted, callback) {
+  if (!id) return;
+  run(`wpctl set-mute ${id} ${muted ? 1 : 0}`, callback);
+}
+
 // --- pw-dump based enumeration ---
 
 // Shared helper: parse pw-dump once, extract app streams, sinks, and sources
@@ -181,6 +187,7 @@ module.exports = {
   setDefault,
   nodeVolume,
   nodeMute,
+  nodeMuteSet,
   getAppList,
   getSinkList,
   getSourceList,

--- a/propertyInspector/appSettings.html
+++ b/propertyInspector/appSettings.html
@@ -47,6 +47,18 @@
       </div>
     </div>
 
+    <div class="sdpi-heading">Button Action</div>
+    <div class="sdpi-item">
+      <div class="sdpi-item-label">Direction</div>
+      <div class="sdpi-item-value">
+        <select id="direction">
+          <option value="up">Up (increase)</option>
+          <option value="down">Down (decrease)</option>
+          <option value="mute">Mute Toggle</option>
+        </select>
+      </div>
+    </div>
+
     <div class="sdpi-heading">Volume Step</div>
     <div class="sdpi-item">
       <div class="sdpi-item-label">Step Size</div>
@@ -135,6 +147,7 @@
 
     function saveSettings() {
       settings.appName = document.getElementById("app-select").value || settings.appName;
+      settings.direction = document.getElementById("direction").value;
       saveDisplaySettings();
       saveVolumeStep();
       sendSettings();
@@ -144,6 +157,9 @@
       document.getElementById("volumeStepLabel").textContent = this.value + "%";
     });
 
+    if (settings.direction) document.getElementById("direction").value = settings.direction;
+
+    document.getElementById("direction").addEventListener("change", saveSettings);
     document.getElementById("app-select").addEventListener("change", saveSettings);
     document.getElementById("customName").addEventListener("change", saveSettings);
     document.getElementById("showName").addEventListener("change", saveSettings);

--- a/propertyInspector/encoderSettings.html
+++ b/propertyInspector/encoderSettings.html
@@ -36,6 +36,18 @@
       </div>
     </div>
 
+    <div class="sdpi-heading">Button Action</div>
+    <div class="sdpi-item">
+      <div class="sdpi-item-label">Direction</div>
+      <div class="sdpi-item-value">
+        <select id="direction">
+          <option value="up">Up (increase)</option>
+          <option value="down">Down (decrease)</option>
+          <option value="mute">Mute Toggle</option>
+        </select>
+      </div>
+    </div>
+
     <div class="sdpi-heading">Volume Step</div>
     <div class="sdpi-item">
       <div class="sdpi-item-label">Step Size</div>
@@ -51,6 +63,7 @@
     initPI();
 
     function saveSettings() {
+      settings.direction = document.getElementById("direction").value;
       saveDisplaySettings();
       saveVolumeStep();
       sendSettings();
@@ -60,6 +73,10 @@
       document.getElementById("volumeStepLabel").textContent = this.value + "%";
     });
 
+    // Restore direction on settings load
+    if (settings.direction) document.getElementById("direction").value = settings.direction;
+
+    document.getElementById("direction").addEventListener("change", saveSettings);
     document.getElementById("customName").addEventListener("change", saveSettings);
     document.getElementById("showName").addEventListener("change", saveSettings);
     document.getElementById("showBar").addEventListener("change", saveSettings);

--- a/propertyInspector/inputSettings.html
+++ b/propertyInspector/inputSettings.html
@@ -47,6 +47,18 @@
       </div>
     </div>
 
+    <div class="sdpi-heading">Button Action</div>
+    <div class="sdpi-item">
+      <div class="sdpi-item-label">Direction</div>
+      <div class="sdpi-item-value">
+        <select id="direction">
+          <option value="up">Up (increase)</option>
+          <option value="down">Down (decrease)</option>
+          <option value="mute">Mute Toggle</option>
+        </select>
+      </div>
+    </div>
+
     <div class="sdpi-heading">Volume Step</div>
     <div class="sdpi-item">
       <div class="sdpi-item-label">Step Size</div>
@@ -113,6 +125,7 @@
 
     function saveSettings() {
       settings.inputName = document.getElementById("input-select").value || settings.inputName;
+      settings.direction = document.getElementById("direction").value;
       saveDisplaySettings();
       saveVolumeStep();
       sendSettings();
@@ -122,6 +135,9 @@
       document.getElementById("volumeStepLabel").textContent = this.value + "%";
     });
 
+    if (settings.direction) document.getElementById("direction").value = settings.direction;
+
+    document.getElementById("direction").addEventListener("change", saveSettings);
     document.getElementById("input-select").addEventListener("change", saveSettings);
     document.getElementById("customName").addEventListener("change", saveSettings);
     document.getElementById("showName").addEventListener("change", saveSettings);

--- a/propertyInspector/outputSettings.html
+++ b/propertyInspector/outputSettings.html
@@ -47,6 +47,18 @@
       </div>
     </div>
 
+    <div class="sdpi-heading">Button Action</div>
+    <div class="sdpi-item">
+      <div class="sdpi-item-label">Direction</div>
+      <div class="sdpi-item-value">
+        <select id="direction">
+          <option value="up">Up (increase)</option>
+          <option value="down">Down (decrease)</option>
+          <option value="mute">Mute Toggle</option>
+        </select>
+      </div>
+    </div>
+
     <div class="sdpi-heading">Volume Step</div>
     <div class="sdpi-item">
       <div class="sdpi-item-label">Step Size</div>
@@ -124,6 +136,7 @@
 
     function saveSettings() {
       settings.outputName = document.getElementById("output-select").value || settings.outputName;
+      settings.direction = document.getElementById("direction").value;
       saveDisplaySettings();
       saveVolumeStep();
       sendSettings();
@@ -133,6 +146,9 @@
       document.getElementById("volumeStepLabel").textContent = this.value + "%";
     });
 
+    if (settings.direction) document.getElementById("direction").value = settings.direction;
+
+    document.getElementById("direction").addEventListener("change", saveSettings);
     document.getElementById("output-select").addEventListener("change", saveSettings);
     document.getElementById("customName").addEventListener("change", saveSettings);
     document.getElementById("showName").addEventListener("change", saveSettings);

--- a/propertyInspector/pushToTalkSettings.html
+++ b/propertyInspector/pushToTalkSettings.html
@@ -1,0 +1,87 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8" />
+  <title>Push to Talk Settings</title>
+  <link rel="stylesheet" href="sdpi.css" />
+</head>
+<body>
+  <div class="sdpi-wrapper">
+    <div class="sdpi-heading">Push to Talk</div>
+    <div class="sdpi-item">
+      <div class="sdpi-item-label">Microphone</div>
+      <div class="sdpi-item-value">
+        <select id="input-select">
+          <option value="" disabled selected>Loading...</option>
+        </select>
+      </div>
+    </div>
+    <div class="sdpi-info">
+      Hold to unmute. Red = muted, green = live.<br/>
+      Mic will always be muted when you release the button.
+    </div>
+  </div>
+
+  <script src="sdpi-common.js"></script>
+  <script>
+    initPI(
+      function onReady(ws, ai) {
+        ws.send(JSON.stringify({
+          event: "sendToPlugin",
+          action: ai.action,
+          context: uuid,
+          payload: { request: "getSourceList" }
+        }));
+      },
+      function onMessage(msg) {
+        if (msg.event === "sendToPropertyInspector") {
+          var payload = msg.payload || {};
+          if (payload.event === "sourceList") populateSourceList(payload.sources || []);
+        }
+        if (msg.event === "didReceiveSettings") selectCurrentInput();
+      }
+    );
+
+    function populateSourceList(sources) {
+      var select = document.getElementById("input-select");
+      select.innerHTML = "";
+
+      if (sources.length === 0) {
+        var opt = document.createElement("option");
+        opt.value = "";
+        opt.textContent = "No input devices found";
+        opt.disabled = true;
+        select.appendChild(opt);
+        return;
+      }
+
+      var placeholder = document.createElement("option");
+      placeholder.value = "";
+      placeholder.textContent = "Select a microphone...";
+      placeholder.disabled = true;
+      select.appendChild(placeholder);
+
+      sources.forEach(function (source) {
+        var opt = document.createElement("option");
+        opt.value = source.nodeName;
+        opt.textContent = source.name;
+        select.appendChild(opt);
+      });
+
+      selectCurrentInput();
+    }
+
+    function selectCurrentInput() {
+      var select = document.getElementById("input-select");
+      if (settings.inputName) select.value = settings.inputName;
+    }
+
+    function saveSettings() {
+      settings.inputName = document.getElementById("input-select").value || settings.inputName;
+      sendSettings();
+    }
+
+    document.getElementById("input-select").addEventListener("change", saveSettings);
+  </script>
+</body>
+</html>


### PR DESCRIPTION
 ⚠️ Breaking change — all buttons must be rebuilt after updating.

  - Consolidated actions (18 → 8): Each audio category (Master, Mic, App, Output, Input) now has a single action. Use the Direction setting
  in the Property Inspector to choose Up, Down, or Mute Toggle per button.
  - Push to Talk: New keypad-only button (Also works on Stream Deck Pedal). Red = muted, green = live. Holds mic unmuted while pressed; always mutes on release. Configurable input device.
  - Encoder behavior unchanged: Dial rotation adjusts volume, dial press toggles mute.