### PR TITLE
Fix icon flashing, enable property inspector scrolling, button action rename

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -6,21 +6,9 @@ STAGE_DIR="${PLUGIN_NAME}.sdPlugin"
 
 cd "$(dirname "$0")"
 
-# Bump patch version in manifest.json and package.json
-NEW_VERSION=$(node -e "
-  const fs = require('fs');
-  const m = JSON.parse(fs.readFileSync('manifest.json'));
-  const p = JSON.parse(fs.readFileSync('package.json'));
-  const parts = m.Version.split('.');
-  parts[2] = String(Number(parts[2]) + 1);
-  const v = parts.join('.');
-  m.Version = v; p.version = v;
-  fs.writeFileSync('manifest.json', JSON.stringify(m, null, 2) + '\n');
-  fs.writeFileSync('package.json', JSON.stringify(p, null, 2) + '\n');
-  process.stdout.write(v);
-")
-OUTPUT="builds/${PLUGIN_NAME}-${NEW_VERSION}.streamDeckPlugin"
-echo "Version: $NEW_VERSION"
+VERSION=$(node -e "process.stdout.write(require('./manifest.json').Version)")
+OUTPUT="builds/${PLUGIN_NAME}-${VERSION}.streamDeckPlugin"
+echo "Version: $VERSION"
 
 echo "Installing dependencies..."
 npm install --omit=dev

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "Name": "PipeWire Audio Control",
   "Description": "Native PipeWire audio control for Linux — master volume, mic, and per-app control.",
   "Author": "sfgrimes",
-  "Version": "0.2.4",
+  "Version": "0.3.0",
   "Icon": "icons/plugin",
   "Category": "Audio",
   "CategoryIcon": "icons/plugin",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "com.sfgrimes.pipewire-audio",
-  "version": "0.2.4",
+  "version": "0.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "com.sfgrimes.pipewire-audio",
-      "version": "0.2.4",
+      "version": "0.3.0",
       "license": "GPL-3.0-only",
       "dependencies": {
         "ws": "^8.18.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.sfgrimes.pipewire-audio",
-  "version": "0.2.4",
+  "version": "0.3.0",
   "description": "PipeWire Native Audio Control Plugin for OpenDeck",
   "main": "index.js",
   "author": "sfgrimes",

--- a/propertyInspector/appSettings.html
+++ b/propertyInspector/appSettings.html
@@ -49,7 +49,7 @@
 
     <div class="sdpi-heading">Button Action</div>
     <div class="sdpi-item">
-      <div class="sdpi-item-label">Direction</div>
+      <div class="sdpi-item-label">Action</div>
       <div class="sdpi-item-value">
         <select id="direction">
           <option value="up">Up (increase)</option>

--- a/propertyInspector/encoderSettings.html
+++ b/propertyInspector/encoderSettings.html
@@ -38,7 +38,7 @@
 
     <div class="sdpi-heading">Button Action</div>
     <div class="sdpi-item">
-      <div class="sdpi-item-label">Direction</div>
+      <div class="sdpi-item-label">Action</div>
       <div class="sdpi-item-value">
         <select id="direction">
           <option value="up">Up (increase)</option>

--- a/propertyInspector/inputSettings.html
+++ b/propertyInspector/inputSettings.html
@@ -49,7 +49,7 @@
 
     <div class="sdpi-heading">Button Action</div>
     <div class="sdpi-item">
-      <div class="sdpi-item-label">Direction</div>
+      <div class="sdpi-item-label">Action</div>
       <div class="sdpi-item-value">
         <select id="direction">
           <option value="up">Up (increase)</option>

--- a/propertyInspector/outputSettings.html
+++ b/propertyInspector/outputSettings.html
@@ -49,7 +49,7 @@
 
     <div class="sdpi-heading">Button Action</div>
     <div class="sdpi-item">
-      <div class="sdpi-item-label">Direction</div>
+      <div class="sdpi-item-label">Action</div>
       <div class="sdpi-item-value">
         <select id="direction">
           <option value="up">Up (increase)</option>

--- a/propertyInspector/sdpi.css
+++ b/propertyInspector/sdpi.css
@@ -16,7 +16,7 @@ html, body {
   color: var(--sdpi-color);
   margin: 0;
   padding: 0;
-  overflow: hidden;
+  overflow-y: auto;
 }
 
 .sdpi-wrapper {


### PR DESCRIPTION
  Icons were being redrawn on every PipeWire event even when nothing changed. Image is now cached and only sends updates when values actually differ from PipeWire.

  Other changes:
  - Property inspector now scrolls when the window is smaller than the options presented.
  - Renamed "Direction" to "Action" in button action drop down now that mute is an option.