### PR TITLE
Refresh other buttons when an "audio switch" button is pressed

### DIFF
--- a/index.js
+++ b/index.js
@@ -655,7 +655,9 @@ function handleKeyDown(action, context, settings) {
       break;
     case "switchoutput":
     case "switchinput":
-      pipewire.setDefault(target, cb);
+      pipewire.setDefault(target, () => {
+        setTimeout(refreshAllTitles, 50);
+      });
       break;
   }
 }


### PR DESCRIPTION
If I want to switch between my speakers and headset, I want the _other_ button to no longer be highlighted when I switch input. 